### PR TITLE
Added: documentation for csrf tokens

### DIFF
--- a/laravel_versioned_docs/version-3.x/40-generating-documentation.md
+++ b/laravel_versioned_docs/version-3.x/40-generating-documentation.md
@@ -13,7 +13,7 @@ php artisan scribe:generate
 
 This will:
 - extract information about your API and endpoints
-- transform the extracted information into a HTML docs webpage (+ Postman collection and OpenAPI spec, if enabled) 
+- transform the extracted information into a HTML docs webpage (+ Postman collection and OpenAPI spec, if enabled)
 - store the extracted API details in some YAML files (in `.scribe/endpoints`), so you can manually edit them later
 
 If you're using [`static` type](./getting-started#1-pick-a-type), your docs (`index.html`, CSS and JS files) will be generated to the `public/docs` folder.
@@ -62,7 +62,7 @@ The `.scribe` folder holds Scribe's intermediate output, allowing you to modify 
 - sort groups (by renaming the group files)
 
 See [sorting endpoints and groups](#sorting-endpoints-and-groups).
-  
+
 ### Discarding your changes
 On future runs, Scribe will respect your changes and try to merge them into any information it extracts. If you'd like to discard your changes and have Scribe extract afresh, you can pass the `--force` flag.
 
@@ -103,10 +103,16 @@ By default, your generated docs will include an API tester that lets users test 
 
 For _Try It Out_ to work, you'll need to make sure CORS is enabled. An easy package for this is [`fruitcake/laravel-cors`](https://github.com/fruitcake/laravel-cors).
 
+:::important
+If you are using [Laravel Sanctum](https://laravel.com/docs/sanctum), or another token-based authentication system on your API, you may need to enable `use_csrf` in the scribe config.
+:::
+
+By default, the setup assumes you are using [Laravel Sanctum](https://laravel.com/docs/sanctum) for your authentication system. The config includes options to tweak how CSRF tokens are fetched in case you are using something else. If `use_csrf` is enabled, before each request is processed, the CSRF token is fetched and applied to the subsequent request.
+
 ## Postman collection and OpenAPI spec
 By default, Scribe will also generate a Postman collection and OpenAPI spec which you can import into API clients like Postman or Insomnia. Scribe will include the links to them in the menu of your docs.
 
-You can configure these in the `postman` and `openapi` sections of your `scribe.php` file. 
+You can configure these in the `postman` and `openapi` sections of your `scribe.php` file.
 
 ```php title=config/scribe.php
 'postman' => [
@@ -131,7 +137,7 @@ Each section has two options:
 ## Customising the environment
 You can pass the `--env` option to run this command with a specific env file. For instance, if you have a `.env.docs` file, running `scribe:generate --env docs` will make Laravel use the `.env.docs` file.
 
-This is a handy way to customise the behaviour of your app for documentation purposes—for example, you can disable things like notifications when response calls are running. 
+This is a handy way to customise the behaviour of your app for documentation purposes—for example, you can disable things like notifications when response calls are running.
 
 ## Running on CI/CD
 You might want to generate your docs as part of your deployment process. Here are a few things to note:

--- a/laravel_versioned_docs/version-3.x/reference/10-config.md
+++ b/laravel_versioned_docs/version-3.x/reference/10-config.md
@@ -27,7 +27,7 @@ Default: `"static"`
 Settings for the `static` type output.
 
 - `output_path`: Output folder. The docs, Postman collection and OpenAPI spec will be placed in this folder. We recommend leaving this as `public/docs`, so people can access your docs through `<your-app>/docs`.
-  
+
    Default: `"public/docs"`.
 
 ### `laravel`
@@ -38,7 +38,7 @@ Settings for the `laravel` type output.
    Default: `true`
 
 - `docs_url`: The path for the documentation endpoint (if `add_routes` is true).
-  
+
    Default: `"/docs"`.
 
 - `middleware`: List of middleware to be attached to the documentation endpoint (if `add_routes` is true).
@@ -67,6 +67,17 @@ For "Try It Out" to work, you'll need to make sure CORS is enabled on your endpo
 :::
 
 - `base_url`: The base URL where Try It Out requests should go to. For instance, you can set this to your staging server.
+- `use_csrf`: Add the X-XSRF-TOKEN to requests being run in Try It Out
+
+  Default: `false`.
+
+- `csrf_url`: The URL where the CSRF token will be added as a cookie in the response
+
+  Default: `'/sanctum/csrf-token'`.
+
+- `csrf_cookie_name`: The name of the cookie that is being used to store the CSRF token
+
+  Default: `'X-XSRF-TOKEN'`.
 
 ### `logo`
 Path to an image to use as your logo in the docs. This will be used as the value of the `src` attribute for the `<img>` tag, so make sure it points to a public URL or path accessible from your server.
@@ -81,7 +92,7 @@ For best results, the image width should be 230px. Set this to `false` if you're
 Default: `false`.
 
 ### `default_group`
-When [documenting your api](/laravel/documenting/), you use `@group` annotations to group API endpoints. Endpoints which do not have a group annotation will be grouped under the `default_group`. 
+When [documenting your api](/laravel/documenting/), you use `@group` annotations to group API endpoints. Endpoints which do not have a group annotation will be grouped under the `default_group`.
 
 Default: `"Endpoints"`.
 
@@ -96,7 +107,7 @@ Along with the HTML docs, Scribe can automatically generate a Postman collection
 For `static` output, the collection will be created in `{static.output_path}/collection.json`. For `laravel` output, the collection will be generated to `storage/app/scribe/collection.json`. Setting `laravel.add_routes` to `true` will add a `/collection.json` endpoint to fetch it.
 
 - `enabled`: Whether or not to generate a Postman API collection.
-  
+
    Default: `true`
 
 - `overrides`: Fields to merge with the collection after generating. Dot notation is supported. For instance, if you'd like to override the `version` in the `info` object, you can set `overrides` to `['info.version' => '2.0.0']`.
@@ -111,7 +122,7 @@ The OpenAPI spec is an opinionated spec that doesn't cover all features of APIs 
 For `static` output, the spec will be created in `{static.output_path}/openapi.yaml`. For `laravel` output, the spec will be generated to `storage/app/scribe/openapi.yaml`. Setting `laravel.add_routes` to `true` will add a `/openapi.yaml` endpoint to fetch it.
 
 - `enabled`: Whether or not to generate an OpenAPI spec.
-  
+
    Default: `false`
 
 - `overrides`: Fields to merge with the spec after generating. Dot notation is supported. For instance, if you'd like to override the `version` in the `info` object, you can set `overrides` to `['info.version' => '2.0.0']`.
@@ -126,7 +137,7 @@ Specify authentication details about your API. This information will be used:
 
 Here are the available settings:
 - `enabled`: Set this to `true` if _any endpoints_ in your API use authentication.
-  
+
    Default: `false`.
 
 - `default`: Specify the default auth behaviour of your API.
@@ -152,7 +163,7 @@ Even if you set `auth.default`, you must also set `auth.enabled` to `true` if yo
 
 - `use_value`: The value of the parameter to be used by Scribe to authenticate response calls. This will **not** be included in the generated documentation. If this is empty, Scribe will use a randomly generated value.
 
-- `placeholder`: The placeholder your users will see for the auth parameter in the example requests. If this is empty, Scribe will generate a realistic-looking auth token instead (for example, "jh86fccvbAx6CmA9VS"). 
+- `placeholder`: The placeholder your users will see for the auth parameter in the example requests. If this is empty, Scribe will generate a realistic-looking auth token instead (for example, "jh86fccvbAx6CmA9VS").
 
   Default: `"{YOUR_AUTH_KEY}"`.
 
@@ -257,7 +268,7 @@ Finally, if you're using Dingo, you can also limit the `versions` you want to ma
 'match' => [
   'prefixes' => ['api/*'],
   'domains' => ['v2.acme.co'],
-  'versions' => ['v2'], 
+  'versions' => ['v2'],
 ],
 
 // 👍 Will match
@@ -281,7 +292,7 @@ For example:
 ],
 'include' => ['public.metrics'],
 'exclude' => ['internal/*'],
-    
+
 
 Route::group(['domain' => 'v2.acme.co'], function () {
   // 👍 Will match
@@ -326,7 +337,7 @@ The `apply` section of the route group is where you specify any additional setti
 ```
 
   - The `methods` key determines what endpoints allow response calls. By default, Scribe will only try response calls for GET endpoints, but you can change this as you wish. Set it to `['*']` to mean all methods. Leave it as an empty array to turn off response calls for that route group.
-  
+
   - The `queryParams`, `bodyParams`, and `fileParams` keys allow you to set specific data to be sent in response calls. For file parameters, each value should be a valid path (absolute or relative to your project directory) to a file on the machine.
 
   - The `config` key allows you to customise your Laravel app's config for the response call.


### PR DESCRIPTION
Documenting the changes in https://github.com/knuckleswtf/scribe/pull/317

Looks like there was some extra trailing whitespace. Hopefully removing that isnt too much noise.

![Screen Shot 2021-09-09 at 11 38 42 AM](https://user-images.githubusercontent.com/1425304/132744016-88d010c3-689b-458b-8d77-5bdfc9a83b7f.png)
![Screen Shot 2021-09-09 at 11 40 00 AM](https://user-images.githubusercontent.com/1425304/132744019-9ba0b53f-e8ed-421e-8b59-d2a3b3ce1146.png)
