### PR TITLE
Correct config key from `responseCalls` to `responses`

### DIFF
--- a/laravel/20-migrating.mdx
+++ b/laravel/20-migrating.mdx
@@ -96,7 +96,7 @@ composer update knuckleswtf/scribe
          ```
        </TabItem>
      </Tabs>
-  - If you previously were using `routes.0.apply.response_calls`, replace it with `ResponseCalls::withSettings(...)` in `strategies.responseCalls`. Note that `methods` has been replaced by `only`, which supports better wildcards (method + URL).
+  - If you previously were using `routes.0.apply.response_calls`, replace it with `ResponseCalls::withSettings(...)` in `strategies.responses`. Note that `methods` has been replaced by `only`, which supports better wildcards (method + URL).
 
       <Tabs
           defaultValue="before"
@@ -126,7 +126,7 @@ composer update knuckleswtf/scribe
         <TabItem value="after">
           ```php
           'strategies' => [
-            'responseCalls' => [
+            'responses' => [
               // Your other strategies...,
               Strategies\Responses\ResponseCalls::withSettings(
                 only: ['GET *'],


### PR DESCRIPTION
I noticed this while checking [config/scribe.php](https://github.com/knuckleswtf/scribe/blob/v5/config/scribe.php).
It seems that `routes.0.apply.response_calls` should belong under `strategies.responses`
instead of `strategies.responseCalls`, so I made this change.

If this is correct, please consider merging it.