### PR TITLE
Update how to specify status code for @apiResource

### DIFF
--- a/laravel/documenting/60-responses.mdx
+++ b/laravel/documenting/60-responses.mdx
@@ -439,7 +439,7 @@ As with `@response`, you can also specify a status code:
 
 ```
 /**
- * @apiResource 201 App\Http\Resources\UserResource
+ * @apiResource App\Http\Resources\UserResource status=201
  * @apiResourceModel App\Models\User
  */
 ```


### PR DESCRIPTION
This PR makes a minor change to how the status code is added with @apiResource.

The documentation seems to have incorrect syntax for adding a status code with @apiResource. When I try the example from the docs, I get the following error:

<img width="3584" height="796" alt="CleanShot 2025-10-28 at 18 57 29@2x" src="https://github.com/user-attachments/assets/e0cd5716-3c19-41e6-91a3-95351178a4bc" />
