### PR TITLE
Document new factoryCreateQuietly response generation method

### DIFF
--- a/laravel/documenting/60-responses.mdx
+++ b/laravel/documenting/60-responses.mdx
@@ -753,6 +753,11 @@ You can customise this process in a few ways:
 ### Changing the strategies
 You can change the order of these strategies, or remove the ones you don't need by editing the `examples.models_source` config item. By default, it's set to `['factoryCreate', 'factoryMake', 'databaseFirst']`, corresponding to the three main strategies above.
 
+
+   :::note
+   `factoryCreate` will dispatch model events resulting in listener execution which could negatively impact generation time in large event driven projects. `factoryCreateQuietly` can be used to suppress model events if they are not a requirement for your generated data.
+   :::
+
 ### Applying states
 If you want specific [states](https://laravel.com/docs/database-testing#factory-states) to be applied to your model factory, you can use the `states` field on `@apiResourceModel` or `@transformerModel`. Separate multiple states with a comma. If you're using attributes, use the `factoryStates:` argument with an array of states.
 


### PR DESCRIPTION
This PR adds documentation for the factoryCreateQuietly strategy added in https://github.com/knuckleswtf/scribe/pull/1057

### Preview

<img width="2672" height="1432" alt="image" src="https://github.com/user-attachments/assets/5ef8df46-f824-4772-b3e2-ae60eba63eeb" />
