### PR TITLE
Fixed #[ResponseFromApiResource] attribute argument

### DIFF
--- a/laravel/documenting/60-responses.mdx
+++ b/laravel/documenting/60-responses.mdx
@@ -520,7 +520,7 @@ public function listMoreUsers()
 </AttributesTagsTabs>
 
 ### Additional Data
-If your endpoint returns additional fields using the API resource's `additional()` method, you can indicate this with `@apiResourceAdditional` or the `merge:` argument to `#[ResponseFromApiResource]`:
+If your endpoint returns additional fields using the API resource's `additional()` method, you can indicate this with `@apiResourceAdditional` or the `additional:` argument to `#[ResponseFromApiResource]`:
 
 <AttributesTagsTabs>
 <TabItem value="tags">

--- a/laravel/reference/20-annotations.md
+++ b/laravel/reference/20-annotations.md
@@ -600,7 +600,7 @@ public function endpoint() {...}
 
 // Additional data
 #[ResponseFromApiResource(UserApiResource::class, User::class, 201,
-    merge: ["result" => "success", "message" => "User created successfully")]
+    additional: ["result" => "success", "message" => "User created successfully")]
 public function endpoint() {...}
 ```
 


### PR DESCRIPTION
This changes the `#[ResponseFromApiResource]` attribute argument from `merged` to `additional` in the document.
I attached the screenshots where I fixed below.

- `/laravel/documenting/responses#additional-data`
    <img width="2014" height="696" alt="scribe-doc-pr-20260302_1" src="https://github.com/user-attachments/assets/e4a7d4df-6b0e-4248-aab3-b882ab84ff5a" />


- `/laravel/reference/annotations#responsefromapiresource`
    <img width="2014" height="985" alt="scribe-doc-pr-20260302_2" src="https://github.com/user-attachments/assets/03818bd4-1943-4b30-8340-f36275f312f5" />


I checked that `additional` property is defined in `#[ResponseFromApiResource]` at the version 5.8.0 of Scribe for Laravel.